### PR TITLE
GetErrorMessage() usage in Load_ePUB()

### DIFF
--- a/src/Reader.au3
+++ b/src/Reader.au3
@@ -217,7 +217,7 @@ Func Load_ePUB($sPath)
     SetSliderLabel($mSlider, 'Operation: Initialize ePUB')
     Local $mEPUB = ePUB_Init($sPath)
     If @error Then
-        SetSliderLabel($mSlider, 'Error: ' & GetErrorMessage($EPUB_INIT, @error))
+	SetSliderLabel($mSlider, 'Error: ' & GetErrorMessage($EPUB_INIT, @error, @extended))
         Return SetError(1, 0, False)
     EndIf
     SetSliderLabel($mSlider, 'Operation: Get files')


### PR DESCRIPTION
in case when sqlite3.dll not exist in program directory
then GetErrorMessage() is not setting message here:
![image](https://github.com/dev-nutu/ePUB-Reader/assets/11089482/6accd09f-2638-4655-b855-ab960fe3532e)

this is due to
https://github.com/dev-nutu/ePUB-Reader/blob/2b4187573c50c9ee01ec4a66ec6de34025e74e82/src/Reader.au3#L210-L222

because `@extended` is not followed to:
https://github.com/dev-nutu/ePUB-Reader/blob/2b4187573c50c9ee01ec4a66ec6de34025e74e82/src/Reader.au3#L220

after using fix from this PR 
```autoit
SetSliderLabel($mSlider, 'Error: ' & GetErrorMessage($EPUB_INIT, @error, @extended))
```


I get:
![image](https://github.com/dev-nutu/ePUB-Reader/assets/11089482/0d6703dc-d152-4bbe-bb19-a6682b447623)
